### PR TITLE
Add navigation to a single player sprite on the screen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,37 +7,101 @@ use ggez::graphics;
 use ggez::graphics::{Color, DrawMode, Point};
 use std::time::Duration;
 
+const SPEED: f32 = 250.0;
+const SIZE: f32 = 50.0;
+
+struct InputState {
+    up: bool,
+    down: bool,
+    left: bool,
+    right: bool,
+}
+
+impl InputState {
+    fn new() -> InputState {
+        return InputState {
+                   up: false,
+                   down: false,
+                   left: false,
+                   right: false,
+               };
+    }
+
+    fn reset(&mut self) {
+        self.up = false;
+        self.down = false;
+        self.left = false;
+        self.right = false;
+    }
+}
+
 struct MainState {
-    pos_x: f32,
+    x: f32,
+    y: f32,
+    input_state: InputState,
 }
 
 impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
-        let s = MainState { pos_x: 0.0 };
+        let window = ctx.gfx_context.get_window();
+        let (width, height) = window.size();
+        let s = MainState {
+            x: width as f32 * 0.5,
+            y: height as f32 * 0.5,
+            input_state: InputState::new(),
+        };
         Ok(s)
     }
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context, _dt: Duration) -> GameResult<()> {
-        self.pos_x = self.pos_x % 800.0 + 1.0;
+    fn update(&mut self, ctx: &mut Context, dt: Duration) -> GameResult<()> {
+        let float_duration = dt.as_secs() as f64 + dt.subsec_nanos() as f64 * 1e-9;
+
+        if self.input_state.up {
+            self.y = self.y - (SPEED * float_duration as f32);
+        }
+        if self.input_state.down {
+            self.y = self.y + (SPEED * float_duration as f32);
+        }
+        if self.input_state.left {
+            self.x = self.x - (SPEED * float_duration as f32);
+        }
+        if self.input_state.right {
+            self.x = self.x + (SPEED * float_duration as f32);
+        }
+        self.input_state.reset();
+
         Ok(())
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
         graphics::clear(ctx);
-        graphics::circle(
-            ctx,
-            DrawMode::Fill,
-            Point {
-                x: self.pos_x,
-                y: 380.0,
-            },
-            100.0,
-            32,
-        )?;
+        graphics::circle(ctx,
+                         DrawMode::Fill,
+                         Point {
+                             x: self.x,
+                             y: self.y,
+                         },
+                         SIZE,
+                         32)?;
         graphics::present(ctx);
         Ok(())
+    }
+
+    fn key_down_event(&mut self, keycode: event::Keycode, keymod: event::Mod, repeat: bool) {
+        match keycode {
+            event::Keycode::Up => self.input_state.up = true,
+            event::Keycode::Down => self.input_state.down = true,
+            event::Keycode::Left => self.input_state.left = true,
+            event::Keycode::Right => self.input_state.right = true,
+            _ => {
+                println!("Key pressed: {:?}, modifier {:?}, repeat: {}",
+                         keycode,
+                         keymod,
+                         repeat);
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,20 +42,34 @@ impl MainState {
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, _ctx: &mut Context, dt: Duration) -> GameResult<()> {
+    fn update(&mut self, ctx: &mut Context, dt: Duration) -> GameResult<()> {
+        let window = ctx.gfx_context.get_window();
+        let (width, height) = window.size();
         let float_duration = dt.as_secs() as f64 + dt.subsec_nanos() as f64 * 1e-9;
 
         if self.input_state.up {
-            self.y = self.y - (SPEED * float_duration as f32);
+            let temp_up = self.y - (SPEED * float_duration as f32);
+            if temp_up - (SIZE / 2.) > 0. {
+                self.y = temp_up;
+            }
         }
         if self.input_state.down {
-            self.y = self.y + (SPEED * float_duration as f32);
+            let temp_down = self.y + (SPEED * float_duration as f32);
+            if temp_down + (SIZE / 2.) < (height as f32) {
+                self.y = temp_down;
+            }
         }
         if self.input_state.left {
-            self.x = self.x - (SPEED * float_duration as f32);
+            let temp_left = self.x - (SPEED * float_duration as f32);
+            if temp_left - (SIZE / 2.) > 0. {
+                self.x = temp_left;
+            }
         }
         if self.input_state.right {
-            self.x = self.x + (SPEED * float_duration as f32);
+            let temp_right = self.x + (SPEED * float_duration as f32);
+            if temp_right + (SIZE / 2.) < (width as f32) {
+                self.x = temp_right;
+            }
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use ggez::conf;
 use ggez::event;
 use ggez::{GameResult, Context};
 use ggez::graphics;
-use ggez::graphics::{Color, DrawMode, Point};
+use ggez::graphics::{DrawMode, Point};
 use std::time::Duration;
 
 const SPEED: f32 = 250.0;
@@ -15,24 +15,6 @@ struct InputState {
     down: bool,
     left: bool,
     right: bool,
-}
-
-impl InputState {
-    fn new() -> InputState {
-        return InputState {
-                   up: false,
-                   down: false,
-                   left: false,
-                   right: false,
-               };
-    }
-
-    fn reset(&mut self) {
-        self.up = false;
-        self.down = false;
-        self.left = false;
-        self.right = false;
-    }
 }
 
 struct MainState {
@@ -48,14 +30,19 @@ impl MainState {
         let s = MainState {
             x: width as f32 * 0.5,
             y: height as f32 * 0.5,
-            input_state: InputState::new(),
+            input_state: InputState {
+                up: false,
+                down: false,
+                left: false,
+                right: false,
+            },
         };
         Ok(s)
     }
 }
 
 impl event::EventHandler for MainState {
-    fn update(&mut self, ctx: &mut Context, dt: Duration) -> GameResult<()> {
+    fn update(&mut self, _ctx: &mut Context, dt: Duration) -> GameResult<()> {
         let float_duration = dt.as_secs() as f64 + dt.subsec_nanos() as f64 * 1e-9;
 
         if self.input_state.up {
@@ -70,7 +57,6 @@ impl event::EventHandler for MainState {
         if self.input_state.right {
             self.x = self.x + (SPEED * float_duration as f32);
         }
-        self.input_state.reset();
 
         Ok(())
     }
@@ -89,18 +75,23 @@ impl event::EventHandler for MainState {
         Ok(())
     }
 
-    fn key_down_event(&mut self, keycode: event::Keycode, keymod: event::Mod, repeat: bool) {
+    fn key_down_event(&mut self, keycode: event::Keycode, _keymod: event::Mod, _repeat: bool) {
         match keycode {
             event::Keycode::Up => self.input_state.up = true,
             event::Keycode::Down => self.input_state.down = true,
             event::Keycode::Left => self.input_state.left = true,
             event::Keycode::Right => self.input_state.right = true,
-            _ => {
-                println!("Key pressed: {:?}, modifier {:?}, repeat: {}",
-                         keycode,
-                         keymod,
-                         repeat);
-            }
+            _ => {}
+        }
+    }
+
+    fn key_up_event(&mut self, keycode: event::Keycode, _keymod: event::Mod, _repeat: bool) {
+        match keycode {
+            event::Keycode::Up => self.input_state.up = false,
+            event::Keycode::Down => self.input_state.down = false,
+            event::Keycode::Left => self.input_state.left = false,
+            event::Keycode::Right => self.input_state.right = false,
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
This patch adds navigation for a single circle sprite on the screen. It implements basic UP/DOWN/LEFT/RIGHT movement, and keeps the player sprite from moving completely off the screen.

I had to add `InputState`, because the handlers `key_down_event` and `key_up_event` don't take a `Context` as a parameter (despite what the examples show), so I had to use those events to set state and then have `update` make changes based on that.

I don't think this is the final way we ought to implement all of this madness, but I think it's a good start to help us sort out the feel of the game.